### PR TITLE
Fix cfg syntax error

### DIFF
--- a/GameData/NavyFish/Plugins/Docking Port Alignment Indicator/moduleDockingNodeNamed.cfg
+++ b/GameData/NavyFish/Plugins/Docking Port Alignment Indicator/moduleDockingNodeNamed.cfg
@@ -33,7 +33,7 @@
     }
     
     //Finally, delete the deprecated module
-    -MODULE[ModuleDockingNodeNamed_deprecated]
+    -MODULE[ModuleDockingNodeNamed_deprecated] {}
 }
 
 //Next, repeat this process for all new parts which don't already have a ModuleDockingNodeNamed (no need to save/restore anything this time)


### PR DESCRIPTION
Hi @mwerle,

I'm using DPAI to test some cfg parser code for KSP-CKAN/CKAN#3525, and I found a minor syntax error.

This pull request fixes it.
(Sorry about the newline at end of file change, I don't know how to tell the GitHub web editor not to add those.)

Cheers!
