### PR TITLE
Update dpai_dictionary_ru.cfg

### DIFF
--- a/GameData/NavyFish/Localization/dpai_dictionary_ru.cfg
+++ b/GameData/NavyFish/Localization/dpai_dictionary_ru.cfg
@@ -10,7 +10,7 @@ Localization
         #dpai_settings                     = Настройки DPAI
         #enable_auto_targeting_and_cycling = Автонаведение и перебор
         #exlude_docked_ports               = Только свободные
-        #restrict_docking_ports            = Только аналогичные
+        #restrict_docking_ports            = Только подходящие
         #gui_scale                         = Размер интерфейса:
         #hud_target_port_icon_size         = Размер маркера цели:
         #invert_alignment_x                = Инверсия соосности X


### PR DESCRIPTION
I am sorry but I'd like to submit my version of Russian localization to community judgement.
Reasons to create another one:
- In the current version some words are not translated (e.g. Target Port, Cycling).
- In Russian, common nouns are not capitalized in the middle of phrase.
- Docking Ports in the Russian version of vanilla game are named either "стыковочный узел" or "шлюз" and never "порт", I follow this practice.
- In general my version more accurately reflects the essence, I believe.
- In two occasions less accurate but shorter variant was used to fit GUI better (to avoid warp or cut off).


Illustration of the last point (please mention the window title and the label to the left of input field):
<img width="258" height="201" alt="image" src="https://github.com/user-attachments/assets/0e8731b8-e906-4d6d-9e84-d15a704703ca" />
